### PR TITLE
תיקון - request מוגדר בסקופ העליון של call, כאן רק מוגדר הערך שלו

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -121,7 +121,7 @@ function Call(call_id, events, timeout) {
 
 	this.get_req_vals = function get_req_vals(req, res, next) {
 
-		const request = {
+		request = {
 			req,
 			res,
 			next


### PR DESCRIPTION
תיקון באג קריטי שגורם לחלק מהפונקציונליות הבסיסית לא לעבוד באופן תקין.

מבטל את השינוי שבוצע בטעות בhttps://github.com/MusiCode1/yemot-router/commit/a2414662938ee5df37726bcf3d78506e35758f73